### PR TITLE
Add guide-buffer denoising preview

### DIFF
--- a/PathTracer-CPP/Camera.h
+++ b/PathTracer-CPP/Camera.h
@@ -14,6 +14,7 @@
 #include "PDF.h"
 #include "PPMPreviewWindow.h"
 #include "Environment.h"
+#include "PostProcess.h"
 
 static double power_heuristic(double pdf_a, double pdf_b)
 {
@@ -118,6 +119,10 @@ public :
 				Ray r = get_ray(i, j, s_i, s_j);
 				return ray_color(r, max_depth, world);
 			},
+			[&](int i, int j)
+			{
+				return trace_pixel_data(get_center_ray(i, j), world);
+			},
 			preview);
 	}
 
@@ -130,6 +135,10 @@ public :
 				const int s_j = sample_index / sqrt_spp;
 				Ray r = get_ray(i, j, s_i, s_j);
 				return ray_color(r, max_depth, world, lights);
+			},
+			[&](int i, int j)
+			{
+				return trace_pixel_data(get_center_ray(i, j), world);
 			},
 			preview);
 	}
@@ -266,8 +275,11 @@ private :
 		std::clog << "\rDone.                 \n";
 	}
 
-	template <typename SampleShader>
-	void render_progressive_impl(SampleShader&& sample_shader, PPMPreviewWindow* preview)
+	template <typename SampleShader, typename GuideShader>
+	void render_progressive_impl(
+		SampleShader&& sample_shader,
+		GuideShader&& guide_shader,
+		PPMPreviewWindow* preview)
 	{
 		initialize();
 
@@ -286,6 +298,10 @@ private :
 		std::vector<unsigned char> preview_pixels;
 		const std::vector<RenderTile> tiles = build_tiles();
 		const int total_samples = sqrt_spp * sqrt_spp;
+
+		std::vector<PixelGuide> guide_buffer(pixel_count);
+		std::vector<Color> filtered_framebuffer(pixel_count);
+		const AtrousDenoiser preview_denoiser;
 
 		auto preview_start_time = std::chrono::steady_clock::now();
 		auto last_preview_update_time = preview_start_time;
@@ -307,6 +323,9 @@ private :
 						accumulation[framebuffer_index] += sample_shader(i, j, sample_index);
 						framebuffer[framebuffer_index] =
 							accumulation[framebuffer_index] / static_cast<double>(sample_index + 1);
+						if (sample_index == 0)
+							guide_buffer[framebuffer_index] = guide_shader(i, j);
+						guide_buffer[framebuffer_index].sample_count = sample_index + 1;
 					}
 				}
 			};
@@ -339,6 +358,26 @@ private :
 					elapsed_seconds.count());
 				last_preview_update_time = now;
 			}
+		}
+
+		if (preview && !preview->IsClosed())
+		{
+			auto now = std::chrono::steady_clock::now();
+			std::chrono::duration<double> elapsed_seconds = now - preview_start_time;
+			PostProcessInput post_input{
+				framebuffer,
+				guide_buffer,
+				image_width,
+				image_height
+			};
+			PostProcessOutput post_output{ filtered_framebuffer };
+			preview_denoiser.Apply(post_input, post_output);
+			copy_framebuffer_to_preview(filtered_framebuffer, preview_pixels);
+			preview->UpdateProgressiveImage(
+				preview_pixels,
+				total_samples,
+				total_samples,
+				elapsed_seconds.count());
 		}
 
 		for (int j = 0; j < image_height; j++)
@@ -829,5 +868,34 @@ private :
 			light_rec.u,
 			light_rec.v,
 			light_rec.p);
+	}
+
+	Ray get_center_ray(int i, int j) const
+	{
+		auto pixel_sample =
+			pixel00_center +
+			i * pixel_delta_u +
+			j * pixel_delta_v;
+
+		auto ray_origin = camera_center;
+		auto ray_direction = pixel_sample - ray_origin;
+
+		return Ray(ray_origin, ray_direction, 0.0);
+	}
+	PixelGuide trace_pixel_data(const Ray& ray, const Hittable& world) const
+	{
+		PixelGuide data;
+
+		HitRecord rec;
+		if (!world.Hit(ray, Interval(0.001, infinity), rec))
+			return data;
+
+		data.valid = true;
+		data.normal = normalize(rec.geo_n);
+		data.depth = rec.t;
+		data.sample_count = 1;
+		data.albedo = rec.mat ? rec.mat->Albedo(rec.u, rec.v, rec.p) : Color(1, 1, 1);
+
+		return data;
 	}
 };

--- a/PathTracer-CPP/Material.h
+++ b/PathTracer-CPP/Material.h
@@ -46,6 +46,11 @@ public:
 	{
 		return 0.0;
 	}
+	// Returns material's original albedo
+	virtual Color Albedo(double u, double v, const Point3& p) const
+	{
+		return Color(1, 1, 1);
+	}
 };
 
 
@@ -78,6 +83,10 @@ public :
 		auto cos_theta = dot(rec.n, normalize(scattered.direction()));
 		return cos_theta <= 0 ? 0 : cos_theta / pi;
 	}
+	Color Albedo(double u, double v, const Point3& p) const override
+	{
+		return tex->value(u, v, p);
+	}
 
 private : 
 	std::shared_ptr<Texture> tex;
@@ -101,6 +110,10 @@ public :
 		s_rec.skip_pdf_ray = Ray(rec.p, reflected, ray_in.time());
 
 		return true;
+	}
+	Color Albedo(double u, double v, const Point3& p) const override
+	{
+		return albedo;
 	}
 
 private :
@@ -336,6 +349,11 @@ public :
 		const double preference = 0.15 + 0.55 * specular_weight + 0.20 * gloss_factor;
 
 		return std::clamp(preference, 0.1, 0.9);
+	}
+
+	Color Albedo(double u, double v, const Point3& p) const override
+	{
+		return base_tex->value(u, v, p);
 	}
 
 private:

--- a/PathTracer-CPP/PathTracer-CPP.vcxproj
+++ b/PathTracer-CPP/PathTracer-CPP.vcxproj
@@ -148,6 +148,7 @@
     <ClInclude Include="ONB.h" />
     <ClInclude Include="PDF.h" />
     <ClInclude Include="Perlin_Noise.h" />
+    <ClInclude Include="PostProcess.h" />
     <ClInclude Include="PPMPreviewWindow.h" />
     <ClInclude Include="Quad.h" />
     <ClInclude Include="Ray.h" />

--- a/PathTracer-CPP/PathTracer-CPP.vcxproj.filters
+++ b/PathTracer-CPP/PathTracer-CPP.vcxproj.filters
@@ -104,5 +104,8 @@
     <ClInclude Include="Environment.h">
       <Filter>头文件</Filter>
     </ClInclude>
+    <ClInclude Include="PostProcess.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/PathTracer-CPP/PostProcess.h
+++ b/PathTracer-CPP/PostProcess.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "My_Common.h"
+
+struct PixelGuide
+{
+	Color albedo = Color(1, 1, 1);
+	Vector3 normal = Vector3(0, 0, 0);
+	double depth = infinity;
+	int sample_count = 0;
+	bool valid = false;
+};
+
+struct PostProcessInput
+{
+	const std::vector<Color>& color;
+	const std::vector<PixelGuide>& guide_buffer;
+	int width = 0;
+	int height = 0;
+};
+
+struct PostProcessOutput
+{
+	std::vector<Color>& color;
+};
+
+class PostProcess
+{
+public:
+	virtual ~PostProcess() = default;
+
+	virtual void Apply(
+		const PostProcessInput& input,
+		PostProcessOutput& output) const = 0;
+};
+
+class AtrousDenoiser : public PostProcess
+{
+public:
+	struct Settings
+	{
+		bool enabled = true;
+		int iterations = 2;
+		double normal_power = 128.0;
+		double depth_scale = 0.02;
+		double color_sigma = 0.08;
+	};
+
+	explicit AtrousDenoiser(Settings settings = {}) : settings(settings) {}
+
+	void Apply(
+		const PostProcessInput& input,
+		PostProcessOutput& output) const override
+	{
+		if (!settings.enabled ||
+			settings.iterations <= 0 ||
+			input.color.empty() ||
+			input.color.size() != input.guide_buffer.size() ||
+			input.width <= 0 ||
+			input.height <= 0)
+		{
+			output.color = input.color;
+			return;
+		}
+
+		std::vector<Color> ping = input.color;
+		std::vector<Color> pong(input.color.size(), Color(0, 0, 0));
+
+		for (int pass = 0; pass < settings.iterations; ++pass)
+		{
+			const int step = 1 << pass;
+			ApplyPass(
+				ping,
+				pong,
+				input.color,
+				input.guide_buffer,
+				input.width,
+				input.height,
+				step);
+			std::swap(ping, pong);
+		}
+
+		output.color = ping;
+	}
+
+private:
+	static constexpr double kernel[5] =
+	{
+		1.0 / 16.0,
+		4.0 / 16.0,
+		6.0 / 16.0,
+		4.0 / 16.0,
+		1.0 / 16.0
+	};
+
+	void ApplyPass(
+		const std::vector<Color>& input_color,
+		std::vector<Color>& output_color,
+		const std::vector<Color>& reference_color,
+		const std::vector<PixelGuide>& guide_buffer,
+		int width,
+		int height,
+		int step) const
+	{
+		output_color.assign(input_color.size(), Color(0, 0, 0));
+
+		for (int y = 0; y < height; ++y)
+		{
+			for (int x = 0; x < width; ++x)
+			{
+				const size_t center_index = static_cast<size_t>(y) * width + x;
+				const PixelGuide& center = guide_buffer[center_index];
+
+				if (!center.valid)
+				{
+					output_color[center_index] = input_color[center_index];
+					continue;
+				}
+
+				Color sum(0, 0, 0);
+				double weight_sum = 0.0;
+
+				for (int ky = -2; ky <= 2; ++ky)
+				{
+					const int sample_y = y + ky * step;
+					if (sample_y < 0 || sample_y >= height)
+						continue;
+
+					for (int kx = -2; kx <= 2; ++kx)
+					{
+						const int sample_x = x + kx * step;
+						if (sample_x < 0 || sample_x >= width)
+							continue;
+
+						const size_t sample_index = static_cast<size_t>(sample_y) * width + sample_x;
+						const PixelGuide& neighbor = guide_buffer[sample_index];
+						if (!neighbor.valid)
+							continue;
+
+						const double spatial_weight = kernel[kx + 2] * kernel[ky + 2];
+						const double edge_weight = EdgeWeight(
+							center,
+							neighbor,
+							reference_color[center_index],
+							reference_color[sample_index]);
+						const double weight = spatial_weight * edge_weight;
+
+						sum += weight * input_color[sample_index];
+						weight_sum += weight;
+					}
+				}
+
+				output_color[center_index] =
+					(weight_sum > 0.0) ? (sum / weight_sum) : input_color[center_index];
+			}
+		}
+	}
+
+	double EdgeWeight(
+		const PixelGuide& center,
+		const PixelGuide& neighbor,
+		const Color& center_color,
+		const Color& neighbor_color) const
+	{
+		const Color center_display = display_transform(center_color);
+		const Color neighbor_display = display_transform(neighbor_color);
+		const double color_diff =
+			(center_display - neighbor_display).length_squared();
+		const double color_sigma2 =
+			std::max(1e-6, settings.color_sigma * settings.color_sigma);
+		const double color_weight =
+			std::exp(-color_diff / color_sigma2);
+
+		const double albedo_diff =
+			(center.albedo - neighbor.albedo).length_squared();
+		const double albedo_weight = std::exp(-albedo_diff / 0.25);
+
+		const double normal_similarity =
+			std::max(dot(center.normal, neighbor.normal), 0.0);
+		const double normal_weight =
+			std::pow(normal_similarity, settings.normal_power);
+
+		const double depth_threshold =
+			std::max(1e-6, settings.depth_scale * std::max(1.0, std::abs(center.depth)));
+		const double depth_weight =
+			std::exp(-std::abs(center.depth - neighbor.depth) / depth_threshold);
+
+		return normal_weight * depth_weight * albedo_weight * color_weight;
+	}
+
+	Settings settings;
+};

--- a/PathTracer-CPP/Renderer.cpp
+++ b/PathTracer-CPP/Renderer.cpp
@@ -1145,7 +1145,7 @@ void README_Showcase()
 	Camera cam;
 	cam.aspect_ratio = 16.0 / 9.0;
 	cam.image_width = 1280;
-	cam.sample_per_pixel = 700;
+	cam.sample_per_pixel = 300;
 	cam.max_depth = 25;
 	cam.vfov = 27;
 	cam.lookfrom = Point3(0.0, 1.55, 12.3);


### PR DESCRIPTION
**新增内容**

- 新增 PostProcess.h：抽出 PostProcess 基类、PostProcessInput/Output、PixelGuide，并实现 AtrousDenoiser。
- Camera.h 接入 guide buffer：每个像素记录 albedo / normal / depth / sample_count / valid。
- Progressive preview 现在保持原始累积图像更新，也就是“噪点从多到少”；只在所有 sample 渲染完成后执行一次 denoise，并用最终后处理图替换预览窗口。
- Material.h 增加 Albedo() 接口，并给 Lambertian / Metal / PBR_Material 实现 albedo 输出。
- A-trous 权重现在同时使用 normal + depth + albedo + display-space color，避免把高光、反射、不同颜色区域直接平均糊掉。

**修复的问题**

- 原来 denoise 被放进 progressive update 里，会导致预览窗口里的后处理效果随时间越来越强；现在改成最终只执行一次。
- 运行过程中曾出现“颜色被严重平均”的情况，主要是滤波缺少颜色边界约束，只靠 normal/depth/albedo 无法保护同一表面上的高光和反射；现在增加了基于原始 framebuffer 的 color weight。
- 修复了后处理接口里输入输出职责不清的问题，现在 input.color 只读，结果写到 PostProcessOutput。
- 修复了 A-trous pass 里 step 自引用/遮蔽导致的逻辑错误。
<img width="1913" height="1074" alt="屏幕截图 2026-06-14 162404" src="https://github.com/user-attachments/assets/2323b263-ad82-43cc-8e6e-178aad053940" />

